### PR TITLE
Test against Ansible 2.7

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,11 +3,12 @@
       jobs:
         - ansible-test-sanity
         - ansible-role-tests-devel-py2
+        - ansible-role-tests-2.7-py3
         - ansible-role-tests-2.6-py2
-        - ansible-role-tests-2.6-py3
     gate:
       jobs:
+        # inverted Python version compared to `check`
         - ansible-test-sanity
-        - ansible-role-tests-devel-py2
-        - ansible-role-tests-2.6-py2
+        - ansible-role-tests-devel-py3
+        - ansible-role-tests-2.7-py2
         - ansible-role-tests-2.6-py3


### PR DESCRIPTION
Rather than having (devel, 2.7,2.6)*(py2, py3) we alternate the Python
versions between check and gate to reduce the number of jobs

Builds on ansible-network/ansible-zuul-jobs#35