### PR TITLE
vyos: Reset role version to devel

### DIFF
--- a/includes/init.yaml
+++ b/includes/init.yaml
@@ -1,7 +1,7 @@
 - name: set the role version
   set_fact:
     ansible_network_vyos_path: "{{ role_path }}"
-    ansible_network_vyos_version: "2.6.0"
+    ansible_network_vyos_version: "devel"
 
 - name: display the role version to stdout
   debug:


### PR DESCRIPTION
- Reset role version to `devel` to denote its back on development track