### PR TITLE
vyos: Remove config_manager_file option from provider

### DIFF
--- a/docs/config_manager/load.md
+++ b/docs/config_manager/load.md
@@ -56,19 +56,6 @@ The configuration file should be the native set of commands used to configure th
 
 The default value is `null`.
 
-This value is *mutually exclusive* with `config_manager_file`.
-
-
-### config_manager_file
-
-This value provides the path to the configuration file to load when
-the function is called. The path to the file can either be provided as
-relative to the playbook root or an absolute path.
-
-The default value is `null`.
-
-This value is *mutually exclusive* with `config_manager_text`.
-
 
 ### config_manager_replace
 

--- a/meta/config_manager/load.yaml
+++ b/meta/config_manager/load.yaml
@@ -3,22 +3,14 @@ argument_spec:
 
   ansible_network_os:
     description:
-      - Set the name of the Ansible network OS platform.  This value should be
+      - Set the name of the Ansible network OS platform. This value should be
         set to `vyos` for this provider.
     required: true
 
   config_manager_text:
     description:
-      - Provide the network device configuration as a single string.  The
+      - Provide the network device configuration as a single string. The
         configuration text will be loaded onto the target network deivce.
-        This parameter is mutually exclusive with config_manager_file.
-    type: str
-
-  config_manager_file:
-    description:
-      - Provide a relative or absolute path to the configuration file to be
-        loaded onto the target network device. This parameter is mutually
-        exclusive with config_manager_text.
     type: str
 
   config_manager_replace:
@@ -27,6 +19,3 @@ argument_spec:
         the function. This argument accepts a boolean value.
     type: bool
     default: false
-
-required_one_of:
-  - ['config_manager_text', 'config_manager_file']

--- a/tasks/config_manager/load.yaml
+++ b/tasks/config_manager/load.yaml
@@ -7,11 +7,6 @@
   validate_role_spec:
     spec: config_manager/load.yaml
 
-- name: lookup config file
-  set_fact:
-    config_manager_text: "{{ lookup('config_template', config_manager_file) | join('\n') }}"
-  when: config_manager_file is defined
-
 - name: validate config_manager_text is defined
   fail:
     msg: "missing required arg: config_manager_text"


### PR DESCRIPTION
- Removing `config_manager_file` option from VyOS provider
- The `config_manager` higher-order role will take care of this