### PR TITLE
Only set tox -elinters to python3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ skipsdist = True
 envlist = linters
 
 [testenv]
-basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
+basepython = python3
 commands =
   flake8 {posargs}
 


### PR DESCRIPTION
This allows us to start to write jobs for centos-7, which doesn't have
python3 by default.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>