### PR TITLE
Configure Vlan to Vyos interfaces 

### DIFF
--- a/tasks/configure_vlans.yaml
+++ b/tasks/configure_vlans.yaml
@@ -1,0 +1,46 @@
+---
+- name: "check for required fact - vlan ID"
+  fail:
+    msg: "missing required fact: Vlan ID"
+  with_items: "{{ vlans }}"
+  when: ( vlan.id is not defined )
+  loop_control:
+    loop_var: vlan
+  delegate_to: localhost
+
+- name: "check for required fact - interface"
+  fail:
+    msg: "missing required fact: Vlan ID"
+  with_items: "{{ vlans }}"
+  when: ( vlan.interface is not defined )
+  loop_control:
+    loop_var: vlan
+  delegate_to: localhost
+
+- name: "check if vlan ID is greater than 1"
+  fail:
+    msg: "vlan_id is less than 1 (valid-range: 1-4094)"
+  with_items: "{{ vlans }}"
+  loop_control:
+    loop_var: vlan
+  when:
+    - vlan.id < 1
+  delegate_to: localhost
+
+- name: "check if vlan ID is less than 4094"
+  fail:
+    msg: "vlan_id is greater than 4094 (valid-range: 1-4094)"
+  with_items: "{{ vlans }}"
+  loop_control:
+    loop_var: vlan
+  when:
+    - vlan.id > 4094
+  delegate_to: localhost
+
+- name: "fetch template for configuring vlan(s)"
+  set_fact:
+    config_manager_text: "{{ lookup('config_template', 'configure_vlans.j2') }}"
+  when: vlans
+
+- include_tasks: config_manager/load.yaml
+  when: vlans

--- a/tasks/configure_vlans.yaml
+++ b/tasks/configure_vlans.yaml
@@ -10,7 +10,7 @@
 
 - name: "check for required fact - interface"
   fail:
-    msg: "missing required fact: Vlan ID"
+    msg: "missing required fact: interface"
   with_items: "{{ vlans }}"
   when: ( vlan.interface is not defined )
   loop_control:
@@ -41,6 +41,7 @@
   set_fact:
     config_manager_text: "{{ lookup('config_template', 'configure_vlans.j2') }}"
   when: vlans
+  delegate_to: localhost
 
 - include_tasks: config_manager/load.yaml
   when: vlans

--- a/templates/configure_vlans.j2
+++ b/templates/configure_vlans.j2
@@ -1,0 +1,12 @@
+{% for vlan in vlans %}
+
+{% if vlan.state is defined and vlan.state == 'absent' %}
+delete interfaces ethernet {{ vlan.interface }} vif {{ vlan.id}}
+
+{% else %}
+
+set interfaces ethernet {{ vlan.interface }} vif {{ vlan.id}} description '{{ vlan.description | default(omit) }}'
+set interfaces ethernet {{ vlan.interface }} vif {{ vlan.id}} address '{{ vlan.address | default(omit) }}'
+
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Added `configure_vlan` and `configure_vlan` jinja template for vyis provider to configure VLANs using vyos provider role.

To configure VLANs via this role user needs to build their playbook as:
```
---
- hosts: vyos
  gather_facts: no
  tasks:
    - import_role:
        name: vyos
        tasks_from: configure_vlans
      vars:
        vlans:
          - interface: eth7
            id: 30
            description: this is vlan 30
            address: 178.18.169.23/24
            #state: absent
          - interface: eth8
            id: 1021
            description: this is vlan 1021
            #state: absent
          - interface: eth6
            id: 40
            address: 178.18.169.1/24
            #state: absent
```