### PR TITLE
Configure VyOs System properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ the function in an Ansible playbook.
 
 * get_facts [[source]](https://github.com/ansible-network/vyos/blob/devel/tasks/get_facts.yaml) [[docs]](https://github.com/ansible-network/vyos/blob/devel/docs/get_facts.md)
 * configure_vlans [[source]](https://github.com/ansible-network/vyos/blob/devel/tasks/configure_vlans.yaml) [[docs]](https://github.com/ansible-network/vyos/blob/devel/docs/configure_vlans.md)
+* configure_system_properties [[source]](https://github.com/ansible-network/vyos/blob/devel/tasks/configure_system_properties) [[docs]](https://github.com/ansible-network/vyos/blob/devel/docs/configure_system_properties.md)
 
 ### Config Manager
 

--- a/docs/configure_system_properties.md
+++ b/docs/configure_system_properties.md
@@ -1,0 +1,99 @@
+# Configure System properties on the device
+
+The `configure_system_properties` function can be used to set system properties on 
+VyOS devices.  This function is only supported over `network_cli` connection
+type and requires the `ansible_network_os` value set to `vyos`.
+
+## How to set System properties on the device
+
+To set System properties on the device, simply include this function in the playbook
+using either the `roles` directive or the `tasks` directive.  If no other
+options are provided, then all of the available facts will be collected for the
+device.
+
+Below is an example of how to use the `roles` directive to set system properties
+on the VyOS device.
+
+```
+- hosts: vyos
+
+  roles:
+  - name ansible-network.vyos
+    function: configure_system_properties
+  vars:
+    system_properties:
+      - hostname: test-vyos
+        domain_name: hostname.com
+        name_server: 192.168.1.1
+```
+
+The above playbook will set the hostname, domain-name and the name-server values to
+the host under the `vyos` top level key.  
+
+### Implement using tasks
+
+The `configure_system_properties` function can also be implemented using the `tasks` 
+directive instead of the `roles` directive.  By using the `tasks` directive, you can
+control when the fact collection is run. 
+
+Below is an example of how to use the `configure_system_properties` function with `tasks`.
+
+```
+- hosts: vyos
+
+  tasks:
+    - name: set system properties to vyos devices
+      import_role:
+        name: ansible-network.vyos
+        tasks_from: configure_system_properties
+      vars:
+        system_properties:
+          - hostname: test-vyos
+            domain_name: hostname.com
+            name_server: 192.168.1.1
+```
+
+## Adding new parsers
+
+Over time new parsers can be added (or updated) to the role to add additional
+or enhanced functionality.  To add or update parsers perform the following
+steps:
+
+* Add (or update) command parser located in `parse_templates/cli`
+
+## Arguments
+
+### hostname
+
+This will set the System host name for the VyOS device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### domain_name
+
+This will set the System domain name for the VyOS device.
+
+The default value is `omit` which means even if the user doesn't pass the respective 
+value the role will continue to run without any failure.
+
+### name_server
+
+This will set the Domain Name Server (DNS) for the VyOS device.
+
+The default value is `omit` which means even if the user doesn't pass the respective 
+value the role will continue to run without any failure.
+
+### state
+
+This will set the hostname, domain-name and name-server value to the VyOS device and if
+the value of the state is changed to `absent`, role will go ahead and try to delete the
+hostname, domain-name and name-server passed via the arguments.
+
+The default value is `present` which means even if the user doesn't pass the respective
+argument, the role will go ahead and try to set the hostname, domain-name and name-server 
+via the arguments passed to the VyOS device.
+
+## Notes
+
+None

--- a/tasks/configure_system_properties.yaml
+++ b/tasks/configure_system_properties.yaml
@@ -1,0 +1,9 @@
+---
+- name: "fetch template for configuring system properties"
+  set_fact:
+    config_manager_text: "{{ lookup('config_template', 'configure_system_properties.j2') }}"
+  when: system_properties
+  delegate_to: localhost
+
+- include_tasks: config_manager/load.yaml
+  when: system_properties

--- a/templates/configure_system_properties.j2
+++ b/templates/configure_system_properties.j2
@@ -1,0 +1,15 @@
+{% for sys_prop in system_properties %}
+
+{% if sys_prop.state is defined and sys_prop.state == 'absent' %}
+delete system host-name {{ sys_prop.hostname | default(omit) }}
+delete system domain-name {{ sys_prop.domain_name | default(omit) }}
+delete system name-server {{ sys_prop.name_server | default(omit) }}
+
+{% else %}
+
+set system host-name {{ sys_prop.hostname | default(omit) }}
+set system domain-name {{ sys_prop.domain_name | default(omit) }}
+set system name-server {{ sys_prop.name_server | default(omit) }}
+
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Added `configure_sys_props` and `configure_sys_props` jinja template for VyOS provider to configure system properties using vyos provider role.

To configure system properties via this role user needs to build their playbook as:
```
---
- hosts: vyos
  gather_facts: no
  tasks:
    - import_role:
        name: vyos
        tasks_from: configure_sys_props
      vars:
        system_properties:
          - hostname: test-vyos-1
            domain_name: hostname-1.com
            name_server: 192.168.1.2
            #state: absent
```