### PR TITLE
vyos: Fix compare functionality

### DIFF
--- a/includes/configure/configure.yaml
+++ b/includes/configure/configure.yaml
@@ -18,7 +18,7 @@
       cli:
         command: compare
       register: vyos_config_diff
-      changed_when: vyos_config_diff.stdout
+      changed_when: vyos_config_diff.stdout is not search("No changes")
 
     - name: display config diff
       debug:


### PR DESCRIPTION
- Fix `compare` functionality which was rendering `changed: True` even when there were no changes.

Depends-On: https://github.com/ansible-network/ansible-zuul-jobs/pull/89
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>