### PR TITLE
Configure LLDP role for VyOS device

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ the function in an Ansible playbook.
 
 * get_facts [[source]](https://github.com/ansible-network/vyos/blob/devel/tasks/get_facts.yaml) [[docs]](https://github.com/ansible-network/vyos/blob/devel/docs/get_facts.md)
 * configure_vlans [[source]](https://github.com/ansible-network/vyos/blob/devel/tasks/configure_vlans.yaml) [[docs]](https://github.com/ansible-network/vyos/blob/devel/docs/configure_vlans.md)
-* configure_system_properties [[source]](https://github.com/ansible-network/vyos/blob/devel/tasks/configure_system_properties) [[docs]](https://github.com/ansible-network/vyos/blob/devel/docs/configure_system_properties.md)
+* configure_system_properties [[source]](https://github.com/ansible-network/vyos/blob/devel/tasks/configure_system_properties.yaml) [[docs]](https://github.com/ansible-network/vyos/blob/devel/docs/configure_system_properties.md)
+* configure_lldp [[source]](https://github.com/ansible-network/vyos/blob/devel/tasks/configure_lldp.yaml) [[docs]](https://github.com/ansible-network/vyos/blob/devel/docs/configure_lldp.md)
 
 ### Config Manager
 

--- a/docs/configure_lldp.md
+++ b/docs/configure_lldp.md
@@ -97,7 +97,8 @@ value the role will continue to run without any failure.
 
 ### snmp
 
-To enable SNMP queries of the LLDP database.
+To enable SNMP queries of the LLDP database. Please note that SNMP must be already 
+configured to enable LLDP SNMP.
 
 The default value is `omit` which means even if the user doesn't pass the respective
 value the role will continue to run without any failure.

--- a/docs/configure_lldp.md
+++ b/docs/configure_lldp.md
@@ -1,0 +1,117 @@
+# Configure LLDP on the device
+
+The `configure_lldp` function can be used to set LLDP on VyOS devices.
+This function is only supported over `network_cli` connection type and 
+requires the `ansible_network_os` value set to `vyos`.
+
+## How to set LLDP on the device
+
+To set LLDP on the device, simply include this function in the playbook
+using either the `roles` directive or the `tasks` directive.  If no other
+options are provided, then all of the available facts will be collected for 
+the device.
+
+Below is an example of how to use the `roles` directive to set LLDP on the 
+VyOS device.
+
+```
+- hosts: vyos
+
+  roles:
+  - name ansible-network.vyos
+    function: configure_lldp
+  vars:
+    lldp:
+      - interface_location: all
+        interface: eth0
+        legacy_protocols: cdp
+        management_address: 192.168.1.1
+        snmp: true
+```
+
+The above playbook will set the LLDP with interface_location, interface,
+legacy_protocols, management_address, and snmp under the `vyos` top level key.  
+
+### Implement using tasks
+
+The `configure_lldp` function can also be implemented using the `tasks` directive
+instead of the `roles` directive.  By using the `tasks` directive, you can
+control when the fact collection is run. 
+
+Below is an example of how to use the `configure_lldp` function with `tasks`.
+
+```
+- hosts: vyos
+
+  tasks:
+    - name: set lldp to vyos devices
+      import_role:
+        name: ansible-network.vyos
+        tasks_from: configure_lldp
+      vars:
+        lldp:
+          - interface_location: all
+            interface: eth0
+            legacy_protocols: cdp
+            management_address: 192.168.1.1
+            snmp: true
+```
+
+## Adding new parsers
+
+Over time new parsers can be added (or updated) to the role to add additional
+or enhanced functionality.  To add or update parsers perform the following
+steps:
+
+* Add (or update) command parser located in `parse_templates/cli`
+
+## Arguments
+
+### interface_location
+
+To Set LLDP listening interfaces.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### interface
+
+To Disable LLDP on respective interface.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### legacy_protocols
+
+To Support other protocols over LLDP.
+
+The default value is `omit` which means even if the user doesn't pass the respective 
+value the role will continue to run without any failure.
+
+### management_address
+
+To define LLDP management-address.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### snmp
+
+To enable SNMP queries of the LLDP database.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### state
+
+This sets the LLDP value to the Cisco IOS-XR device and if the value of the state is changed
+to `absent`, the role will go ahead and try to delete the condifured LLDP via the arguments
+passed.
+
+The default value is `present` which means even if the user doesn't pass the respective
+argument, the role will go ahead and try to set the LLDP via the arguments passed to the 
+Cisco IOS-XR device.
+
+## Notes
+
+None

--- a/docs/configure_lldp.md
+++ b/docs/configure_lldp.md
@@ -105,13 +105,13 @@ value the role will continue to run without any failure.
 
 ### state
 
-This sets the LLDP value to the Cisco IOS-XR device and if the value of the state is changed
+This sets the LLDP value to the VyOS device and if the value of the state is changed
 to `absent`, the role will go ahead and try to delete the condifured LLDP via the arguments
 passed.
 
 The default value is `present` which means even if the user doesn't pass the respective
 argument, the role will go ahead and try to set the LLDP via the arguments passed to the 
-Cisco IOS-XR device.
+VyOS device.
 
 ## Notes
 

--- a/tasks/configure_lldp.yaml
+++ b/tasks/configure_lldp.yaml
@@ -1,0 +1,9 @@
+---
+- name: "fetch template for configuring lldp"
+  set_fact:
+    config_manager_text: "{{ lookup('config_template', 'configure_lldp.j2') }}"
+  when: lldp
+  delegate_to: localhost
+
+- include_tasks: config_manager/load.yaml
+  when: lldp

--- a/templates/configure_lldp.j2
+++ b/templates/configure_lldp.j2
@@ -1,0 +1,20 @@
+{% for item in lldp %}
+
+{% if item.state is defined and item.state == 'absent' %}
+delete service lldp
+
+{% else %}
+
+set service lldp
+set service lldp interface {{ item.interface_location | default(omit) }}
+{% if item.interface is defined %}
+set service lldp interface {{ item.interface | default(omit) }} disable
+{% endif %}
+set service lldp legacy-protocols {{ item.legacy_protocols | default(omit) }}
+set service lldp management-address {{ item.management_address | default(omit) }}
+{% if item.snmp is defined %}
+set service lldp snmp enable
+{% endif %}
+
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Added `configure_lldp` and `configure_lldp` jinja template for VyOS provider to configure lldp using vyos provider role.

To configure lldp via this role user needs to build their playbook as:
```
---
- hosts: vyos
  gather_facts: no
  tasks:
    - import_role:
        name: vyos
        tasks_from: configure_lldp
      vars:
        lldp:
          - interface_location: all
            interface: eth0
            legacy_protocols: cdp
            management_address: 192.168.1.1
            snmp: true
            #state: absent
```

