### PR TITLE
vyos: Changed vyos load and replace tests

### DIFF
--- a/tests/config_manager/config_manager/tasks/load.yml
+++ b/tests/config_manager/config_manager/tasks/load.yml
@@ -3,10 +3,12 @@
     msg: "START config_manager/load.yaml configure function on connection={{ ansible_connection }}"
 
 - name: setup - remove interfaces to configure
-  vyos_config: &rm
-    lines:
-      - delete interfaces ethernet eth1
-      - delete interfaces ethernet eth2
+  cli_config: &rm
+    config: "{{ lines }}"
+  vars: &lines
+    lines: |
+      delete interfaces ethernet eth1
+      delete interfaces ethernet eth2
 
 - name: include vyos load function
   include_role:
@@ -19,16 +21,17 @@
         set interfaces ethernet eth2 description test-interface-2"
 
 - name: fetch interfaces configuration
-  vyos_command:
-    commands: show configuration commands | grep interfaces
+  cli_command:
+    command: show configuration commands | match interfaces
   register: result
 
 - assert:
     that:
-      - "'set interfaces ethernet eth1 description \\'test-interface\\'' in result.stdout_lines[0]"
-      - "'set interfaces ethernet eth2 description \\'test-interface-2\\'' in result.stdout_lines[0]"
+      - "'set interfaces ethernet eth1 description \\'test-interface\\'' in result.stdout_lines"
+      - "'set interfaces ethernet eth2 description \\'test-interface-2\\'' in result.stdout_lines"
 
 - name: teardown - remove interfaces
-  vyos_config: *rm
+  cli_config: *rm
+  vars: *lines
 
-- debug: msg="END config_manager/load.yaml confgiure function on connection={{ ansible_connection }}"
+- debug: msg="END config_manager/load.yaml configure function on connection={{ ansible_connection }}"

--- a/tests/config_manager/config_manager/tasks/replace.yml
+++ b/tests/config_manager/config_manager/tasks/replace.yml
@@ -1,45 +1,67 @@
 ---
-- debug: 
+- debug:
     msg: "START config_manager/load.yaml replace function on connection={{ ansible_connection }}"
 
-- name: setup - remove syslog
-  vyos_config: &rm
-    lines:
-      - delete interfaces ethernet eth1
-      - delete interfaces ethernet eth2
+- name: setup - remove interface config
+  cli_config:
+    config: "{{ lines }}"
+    commit: yes
+  vars:
+    lines: |
+      delete interfaces ethernet eth1
+      delete interfaces ethernet eth2
 
-- name: fetch configuration
-  vyos_command:
-    commands: show configuration commands
-  register: show_config_result
+- name: save running-config to startup-config
+  cli_command:
+    command: "{{ item }}"
+  loop:
+    - configure
+    - save
+    - exit
+
+- name: fetch startup configuration for replace function
+  cli_command:
+    command: cat /config/config.boot
+  register: config_for_replace
 
 - name: configure interfaces
-  vyos_config:
-    lines:
-      - set interfaces ethernet eth1
-      - set interfaces ethernet eth1 description test-interface
-      - set interfaces ethernet eth2
-      - set interfaces ethernet eth2 description test-interface-2
+  cli_config:
+    config: "{{ lines }}"
+    commit: yes
+  vars:
+    lines: |
+      set interfaces ethernet eth1
+      set interfaces ethernet eth1 description test-interface
+      set interfaces ethernet eth2
+      set interfaces ethernet eth2 description test-interface-2
 
-- name: include vyos load function
+- name: fetch running configuration to confirm that new interfaces exist
+  cli_command:
+     command: show configuration commands | match interfaces
+  register: show_config_result
+
+- assert:
+    that:
+      - "'set interfaces ethernet eth1 description \\'test-interface\\'' in show_config_result.stdout_lines"
+      - "'set interfaces ethernet eth2 description \\'test-interface-2\\'' in show_config_result.stdout_lines"
+
+- name: include vyos load function for replace operation
   include_role:
     name: "{{ vyos_role_path }}"
     tasks_from: config_manager/load
   vars:
     config_manager_replace: True
-    config_manager_text: "{{ show_config_result.stdout[0] }}"
+    config_manager_text: "{{ config_for_replace.stdout }}"
 
-- name: fetch configuration
-  junos_command:
-    commands: show configuration commands
+- name: fetch running configuration
+  cli_command:
+    command: show configuration commands | match interfaces
   register: show_config_result
 
 - assert:
     that:
-      - "'set interfaces ethernet eth1 desctiption \\'test-interface\\'' not in show_config_result.stdout_lines[0]"
-      - "'set interfaces ethernet eth2 description \\'test-interface-2\\'' not in show_config_result.stdout_lines[0]"
+      - "'set interfaces ethernet eth1 description \\'test-interface\\'' not in show_config_result.stdout_lines"
+      - "'set interfaces ethernet eth2 description \\'test-interface-2\\'' not in show_config_result.stdout_lines"
 
-- name: teardown - remove syslog config
-  vyos_config: *rm
-
-- debug: msg="END config_manager/load.yaml replace function on connection={{ ansible_connection }}"
+- debug: 
+    msg: "END config_manager/load.yaml replace function on connection={{ ansible_connection }}"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

- Tests for load will now use `cli_config` and `cli_command`
- It appears that the running configuration is successfully replaced only when the candidate configuration has
```
/* Warning: Do not remove the following line. */
/* === vyatta-config-version: "cluster@1:config-management@1:conntrack-sync@1:conntrack@1:cron@1:dhcp-relay@1:dhcp-server@4:firewall@5:ipsec@4:nat@4:qos@1:quagga@2:system@6:vrrp@1:wanloadbalance@3:webgui@1:webproxy@1:zone-policy@1" === */
/* Release version: VyOS 1.1.8 *
```
- Attempting to replacing the running-config with the backed up output of `show configuration` or `show configuration commands` fails.
- The replace tests now use the startup config, i.e, the contents of `/config/config.boot`